### PR TITLE
GitHub Pages 배포 workflow에 권한 속성 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
**개요**
GitHub Pages 배포 workflow에 권한 속성 추가

**변경점**
1. GitHub Pages 배포 workflow에 권한 속성 추가

**추가 내용**
Workflow 정상 작동 여부 테스트 필요
